### PR TITLE
Update package.json, add README.md

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,0 +1,37 @@
+# Prerequisites
+
+## node/npm
+
+Install [node/npm](https://nodejs.org/en/download/) if you haven't already. This was tested with node 6.9.
+
+## [flatbuffers](https://github.com/google/flatbuffers)
+
+You must have `flatc` on your path, or set in the environment variable `FLATC`. The version used must be newer than Sept 2020, as we need [this fix](https://github.com/google/flatbuffers/commit/c30a87de6fc741d7dfcf1f721a69d89ca27a0866). They do not have a tagged version yet with this fix (as of this writing).
+
+To clone, build, and install flatc:
+
+```
+git clone https://github.com/google/flatbuffers.git
+cd flatbuffers
+git checkout c30a87de6fc741d7dfcf1f721a69d89ca27a0866
+cmake -G "Unix Makefiles"
+make install
+```
+
+# Building
+
+## `build.sh`
+
+Uses flatc to generate the proto files necessary. Must run this before running an `npm run build`
+
+## `npm install`
+
+Installs all necessary dependencies for building
+
+## `npm run build`
+
+Build the project and output it to the `dist` folder
+
+## `npm run tsc`
+
+Generate debug types for TypeScript

--- a/javascript/generateSchemas.sh
+++ b/javascript/generateSchemas.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
+# Generate the flatbuffer Schemas used by Deephaven
 
 set -e
 
 # Must point to a build of flatc that is from sept 2020 or newer
+# In particular, must have this fix: https://github.com/google/flatbuffers/commit/c30a87de6fc741d7dfcf1f721a69d89ca27a0866
 if [ -z "$FLATC" ]; then
   echo "FLATC was not set, attempting to use it from path";
   FLATC='flatc'

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -441,6 +441,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -1303,6 +1313,13 @@
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -2170,6 +2187,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -3532,7 +3556,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,18 +1,17 @@
 {
   "name": "@deephaven/barrage",
-  "version": "0.0.1",
-  "description": "Barrage",
+  "version": "0.1.0",
+  "description": "Deephaven Barrage protocol",
   "main": "dist/barrage.js",
   "types": "dist/typings/index.d.ts",
   "scripts": {
-    "clean": "rm -rf dist",
-    "postbootstrap": "npm run lib:build",
-    "lib:build": "npm run clean && webpack",
-
+    "clean": "rimraf ./dist",
+    "build": "npm run clean && ./generateSchemas.sh && webpack",
+    "prepublishOnly": "npm run build",
     "tsc": "tsc --traceResolution -p tsconfig.json"
   },
   "publishConfig": {
-    "access": "public"
+    "registry": "https://npm.pkg.github.com"
   },
   "author": "Deephaven Data Labs",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Set publishConfig to publish to GitHub packages (we can change to npmjs later, we just don't have an org there yet)
- Remove postbootstrap script, it wasn't used
- Renamed lib:build => build, added generating schemas to the build step
- Added README.md with instructions on how to build a specific version of flatc