### PR TITLE
Add `reverseViewport` field to `BarrageUpdateMetadata`

### DIFF
--- a/docs/wire-guide.md
+++ b/docs/wire-guide.md
@@ -23,7 +23,7 @@ There are three different wire types that you will need to become familiar with 
 
 ## Row Set / Index Wire Format
 
-An Index is serialized as a series of commands. Each command is one-byte
+A Row Set is serialized as a series of commands. Each command is one-byte
 split into a 5-bit (high) value and a 3-bit (low) value.
 
 Possible Command Types (most significant 5 bits):
@@ -52,12 +52,12 @@ shorts or bytes depending on the command type. The offset command is a single
 value (then followed by the next command).
 
 The series of values parsed from the previous paragraph can be used to
-reconstruct an Index. Since an Index is an ordered set, all of the values that
+reconstruct a Row Set. Since a Row Set is an ordered set, all of the values that
 we insert, should always be increasing and thus positive. The algorithm then
 uses the sign to encode a single value (a positive value) vs a rangle
 (a positive value followed by a negative value).
 
-To reconstruct the Index run the parsed values through this pseudo code:
+To reconstruct the Row Set run the parsed values through this pseudo code:
 
 ```java
 long pending = -1;
@@ -80,9 +80,9 @@ void consume(long nextOffset) {
 ## IndexShiftData Wire Format
 
 Hopefully you were able to follow the previous section. `IndexShiftData`'s
-binary encoding is three `Index` encodings without any padding in-between.
+binary encoding is three `Row Set` encodings without any padding in-between.
 
-The three Indexes are `starts`, `ends` and `dests`. Each Index will have the
+The three Row Sets are `starts`, `ends` and `dests`. Each Row Set will have the
 same length. Let `s_i = starts[i]`, `e_i = ends[i]`, `d_i = dests[i]`, then this
 triplet represents the notification that all data in keyspace `[s_i, e_i]` (inclusive)
 moved to `[d_i, d_i + e_i - s_i]`. 

--- a/docs/wire-guide.md
+++ b/docs/wire-guide.md
@@ -19,7 +19,7 @@ title: Wire Guide
 -->
 
 There are three different wire types that you will need to become familiar with to parse and process a 
-`BarrageUpdateMetadata`. You will also need to know how to write your own  Row Set / Index to set a viewport.
+`BarrageUpdateMetadata`. You will also need to know how to write your own  Row Set to set a viewport.
 
 ## Row Set Wire Format
 
@@ -59,7 +59,7 @@ value (then followed by the next command).
 
 The series of values parsed from the previous paragraph can be used to
 reconstruct a Row Set. Since a Row Set is an ordered set, all of the values that
-we insert, should always be increasing and thus positive. The algorithm then
+we insert should always be increasing and thus positive. The algorithm then
 uses the sign to encode a single value (a positive value) vs a rangle
 (a positive value followed by a negative value).
 
@@ -83,10 +83,10 @@ void consume(long nextOffset) {
 }
 ```
 
-## IndexShiftData Wire Format
+## RowSetShiftData Wire Format
 
-Hopefully you were able to follow the previous section. `IndexShiftData`'s
-binary encoding is three `Row Set` encodings without any padding in-between.
+To implement [row shifts](https://deephaven.io/core/docs/conceptual/table-update-model/#shifts), 
+`RowSetShiftData` is a binary encoding of three `Row Set` encodings without any padding in-between.
 
 The three Row Sets are `starts`, `ends` and `dests`. Each Row Set will have the
 same length. Let `s_i = starts[i]`, `e_i = ends[i]`, `d_i = dests[i]`, then this
@@ -96,8 +96,8 @@ moved to `[d_i, d_i + e_i - s_i]`.
 :::note 
 
 Note that not all rows are required to exist within the shift; it is recommended to avoid iterating through 
-the entire range. See [IndexShiftData](https://github.com/deephaven/deephaven-core/blob/main/DB/src/main/java/io/deephaven/db/v2/utils/IndexShiftData.java)
-for insipration.
+the entire range. See [RowSetShiftData](https://github.com/deephaven/deephaven-core/blob/main/engine/rowset/src/main/java/io/deephaven/engine/rowset/RowSetShiftData.java)
+for inspiration.
 
 :::
 

--- a/docs/wire-guide.md
+++ b/docs/wire-guide.md
@@ -21,10 +21,16 @@ title: Wire Guide
 There are three different wire types that you will need to become familiar with to parse and process a 
 `BarrageUpdateMetadata`. You will also need to know how to write your own  Row Set / Index to set a viewport.
 
-## Row Set / Index Wire Format
+## Row Set Wire Format
 
 A Row Set is serialized as a series of commands. Each command is one-byte
 split into a 5-bit (high) value and a 3-bit (low) value.
+
+:::note
+
+[Deephaven Enterprise](https://deephaven.io/enterprise/) uses the term `Index` instead of `Row Set` to refer to this concept.
+
+:::
 
 Possible Command Types (most significant 5 bits):
 

--- a/format/Barrage.fbs
+++ b/format/Barrage.fbs
@@ -199,10 +199,6 @@ table BarrageUpdateMetadata {
   /// will be included in the payload. It is an encoded and compressed RowSet.
   effective_viewport: [byte];
 
-  /// When this is set the effective_viewport RowSet will be inverted against the length of the table. That is to say the
-  /// every index value is converted from `i` to `n - i` if the table has `n` rows.
-  effective_reverse_viewport: bool;
-
   /// If this is a snapshot, then the effectively subscribed column set will be included in the payload.
   effective_column_set: [byte];
 
@@ -222,4 +218,8 @@ table BarrageUpdateMetadata {
 
   /// The list of modified column data are in the same order as the field nodes on the schema.
   mod_column_nodes: [BarrageModColumnMetadata];
+
+  /// When this is set the effective_viewport RowSet will be inverted against the length of the table. That is to say the
+  /// every index value is converted from `i` to `n - i` if the table has `n` rows.
+  effective_reverse_viewport: bool;
 }

--- a/format/Barrage.fbs
+++ b/format/Barrage.fbs
@@ -199,6 +199,10 @@ table BarrageUpdateMetadata {
   /// will be included in the payload. It is an encoded and compressed RowSet.
   effective_viewport: [byte];
 
+  /// When this is set the effective_viewport RowSet will be inverted against the length of the table. That is to say the
+  /// every index value is converted from `i` to `n - i` if the table has `n` rows.
+  effective_reverse_viewport: bool;
+
   /// If this is a snapshot, then the effectively subscribed column set will be included in the payload.
   effective_column_set: [byte];
 

--- a/format/Barrage.fbs
+++ b/format/Barrage.fbs
@@ -115,7 +115,7 @@ table BarrageSubscriptionRequest {
   subscription_options: BarrageSubscriptionOptions;
 
   /// When this is set the viewport RowSet will be inverted against the length of the table. That is to say
-  /// every position value is converted from `i` to `n - i` if the table has `n` rows.
+  /// every position value is converted from `i` to `n - i - 1` if the table has `n` rows.
   reverse_viewport: bool;
 }
 
@@ -149,7 +149,7 @@ table BarrageSnapshotRequest {
   snapshot_options: BarrageSnapshotOptions;
 
   /// When this is set the viewport RowSet will be inverted against the length of the table. That is to say
-  /// every position value is converted from `i` to `n - i` if the table has `n` rows.
+  /// every position value is converted from `i` to `n - i - 1` if the table has `n` rows.
   reverse_viewport: bool;
 }
 
@@ -220,6 +220,6 @@ table BarrageUpdateMetadata {
   mod_column_nodes: [BarrageModColumnMetadata];
 
   /// When this is set the viewport RowSet will be inverted against the length of the table. That is to say
-  /// every position value is converted from `i` to `n - i` if the table has `n` rows.
+  /// every position value is converted from `i` to `n - i - 1` if the table has `n` rows.
   effective_reverse_viewport: bool;
 }

--- a/format/Barrage.fbs
+++ b/format/Barrage.fbs
@@ -114,8 +114,8 @@ table BarrageSubscriptionRequest {
   /// Options to configure your subscription.
   subscription_options: BarrageSubscriptionOptions;
 
-  /// When this is set the viewport RowSet will be inverted against the length of the table. That is to say the
-  /// every index value is converted from `i` to `n - i` if the table has `n` rows.
+  /// When this is set the viewport RowSet will be inverted against the length of the table. That is to say
+  /// every position value is converted from `i` to `n - i` if the table has `n` rows.
   reverse_viewport: bool;
 }
 
@@ -148,8 +148,8 @@ table BarrageSnapshotRequest {
   /// Options to configure your subscription.
   snapshot_options: BarrageSnapshotOptions;
 
-  /// When this is set the viewport RowSet will be inverted against the length of the table. That is to say the
-  /// every index value is converted from `i` to `n - i` if the table has `n` rows.
+  /// When this is set the viewport RowSet will be inverted against the length of the table. That is to say
+  /// every position value is converted from `i` to `n - i` if the table has `n` rows.
   reverse_viewport: bool;
 }
 
@@ -219,7 +219,7 @@ table BarrageUpdateMetadata {
   /// The list of modified column data are in the same order as the field nodes on the schema.
   mod_column_nodes: [BarrageModColumnMetadata];
 
-  /// When this is set the effective_viewport RowSet will be inverted against the length of the table. That is to say the
-  /// every index value is converted from `i` to `n - i` if the table has `n` rows.
+  /// When this is set the viewport RowSet will be inverted against the length of the table. That is to say
+  /// every position value is converted from `i` to `n - i` if the table has `n` rows.
   effective_reverse_viewport: bool;
 }


### PR DESCRIPTION
To support reverse viewport subscriptions, the server needs to inform the client whether it is using a forward or reverse viewport.

Add the the field `effective_reverse_viewport: bool;` to`BarrageUpdateMetadata`