### PR TITLE
Updated `barrage` batch count fields to `long`

### DIFF
--- a/docs/rpc-interface.md
+++ b/docs/rpc-interface.md
@@ -215,10 +215,10 @@ table BarrageModColumnMetadata {
 /// batch for a ticking barrage table.
 table BarrageUpdateMetadata {
   /// The number of record batches that describe rows added (may be zero).
-  num_add_batches: ushort;
+  num_add_batches: long;
 
   /// The number of record batches that describe rows modified (may be zero).
-  num_mod_batches: ushort;
+  num_mod_batches: long;
 
   /// This batch is generated from an upstream table that ticks independently of the stream. If
   /// multiple events are coalesced into one update, the server may communicate that here for

--- a/format/Barrage.fbs
+++ b/format/Barrage.fbs
@@ -182,10 +182,10 @@ table BarrageModColumnMetadata {
 /// batch for a ticking barrage table.
 table BarrageUpdateMetadata {
   /// The number of record batches that describe rows added (may be zero).
-  num_add_batches: ushort;
+  num_add_batches: long;
 
   /// The number of record batches that describe rows modified (may be zero).
-  num_mod_batches: ushort;
+  num_mod_batches: long;
 
   /// This batch is generated from an upstream table that ticks independently of the stream. If
   /// multiple events are coalesced into one update, the server may communicate that here for


### PR DESCRIPTION
Change the `num_add_batches`/`num_mod_batches` fields from `ushort` to `long` to support retrieving very large tables.

Closes https://github.com/deephaven/deephaven-core/issues/2280 in`deephaven-core`