### PR TITLE
Add a table_size to barrage update metadata

### DIFF
--- a/format/Barrage.fbs
+++ b/format/Barrage.fbs
@@ -226,4 +226,7 @@ table BarrageUpdateMetadata {
 
   /// The list of modified column data are in the same order as the field nodes on the schema.
   mod_column_nodes: [BarrageModColumnMetadata];
+
+  /// The current size of the table.
+  table_size: long;
 }


### PR DESCRIPTION
With the changes to the viewport protocol, now jsapi cannot inform users what the total size of the table is. This enables us to still inform clients what the current table's size is.