### PR TITLE
docs: move docs back into the barrage repo and setup publishing (DOC-703)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.tag || github.head_ref || github.ref_name }}
+          ref: ${{ github.event.pull_request.head.ref || github.event.inputs.tag || github.ref_name }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Deploy Docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,18 +1,14 @@
 name: Build and Deploy Docs
 
 on:
-  # Trigger workflow manually with inputs
   workflow_dispatch:
     inputs:
       tag:
         description: 'Tag to checkout'
         required: true
-        default: 'latest'
-  # Trigger workflow automatically on new tag creation
   push:
     tags:
       - '*'
-  # Trigger workflow on pull request changes
   pull_request:
     branches:
       - 'main'
@@ -21,35 +17,19 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-
-      # Checkout the repository
-      - name: Set ref variable
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
-          else
-            echo "ref=${{ github.ref_name }}" >> $GITHUB_ENV
-          fi
-
-      - name: Docs
-        run: |
-          echo "Resolved event name: ${{ github.event_name }}"
-          echo "Resolved ref: ${{ env.ref }}"
-
-
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.ref }}
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
           
       - name: Deploy Docs
         run: |
           echo "Deploying docs for tag: ${{ github.event.inputs.tag || github.ref_name }}"
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            pr_number=$(echo "${{ github.ref_name }}" | grep -oP '^\d+')
+            pr_number=${{ github.event.pull_request.number }}
             echo "version=pr-${pr_number}" >> $GITHUB_ENV
             echo "production=false" >> $GITHUB_ENV
           else
@@ -63,20 +43,23 @@ jobs:
           source: docs/
           destination: deephaven/barrage/${{ env.version }}/
           production: ${{ env.production }}
-          temporary: ${{ env.production == 'true' && 'false' || 'true' }}
+          temporary: ${{ env.production != 'true' }}
           aws-role: ${{ vars.DOCS_AWS_ROLE }}
 
       - name: Comment on PR
-        if: ${{ github.event.workflow_run.event == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@v7
         env:
             url: ${{ vars.DOCS_PREVIEW_URL }}
         with:
             script: |
                 const env = process.env;
+                if (!env.url) {
+                  throw new Error("DOCS_PREVIEW_URL is not defined");
+                }
                 github.rest.issues.createComment({
-                issue_number: env.version.replace('pr-', ''),
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `[Barrage docs preview](${env.url}/barrage/${env.version}/docs) (Available for 14 days)`
+                  issue_number: parseInt(env.version.replace('pr-', ''), 10),
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: `[Barrage docs preview](${env.url}/barrage/${env.version}/docs) (Available for 14 days)`
                 });

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,15 +33,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.event.inputs.tag || github.ref_name }}
           
       - name: Deploy Docs
         run: |
           echo "Deploying docs for tag: ${{ github.event.inputs.tag || github.ref_name }}"
-          echo "version=${{ github.event.inputs.tag || github.ref_name }}" >> $GITHUB_ENV
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            pr_number=$(echo "${{ github.ref_name }}" | grep -oP '^\d+')
+            echo "version=pr-${pr_number}" >> $GITHUB_ENV
             echo "production=false" >> $GITHUB_ENV
           else
+            echo "version=${{ github.event.inputs.tag || github.ref_name }}" >> $GITHUB_ENV
             echo "production=true" >> $GITHUB_ENV
           fi
     

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,12 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
           else
-            echo "ref=${{ github.event.inputs.tag || github.ref_name }}" >> $GITHUB_ENV
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              echo "ref=dmckenzie_bring_docs_home" >> $GITHUB_ENV
+            else
+              echo "ref=48/merge" >> $GITHUB_ENV
+            fi
+          fi
 
       - name: Docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,65 @@
+name: Build and Deploy Docs
+
+on:
+  # Trigger workflow manually with inputs
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to checkout'
+        required: true
+        default: 'latest'
+  # Trigger workflow automatically on new tag creation
+  push:
+    tags:
+      - '*'
+  # Trigger workflow on pull request changes
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'docs/**'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+
+      - name: Deploy Docs
+        run: |
+          echo "Deploying docs for tag: ${{ github.event.inputs.tag || github.ref_name }}"
+          echo "version=${{ github.event.inputs.tag || github.ref_name }}" >> $GITHUB_ENV
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "production=false" >> $GITHUB_ENV
+          else
+            echo "production=true" >> $GITHUB_ENV
+          fi
+    
+      - name: Sync docs to S3
+        uses: deephaven/salmon-sync@v1
+        with:
+          source: docs/
+          destination: deephaven/barrage/${{ env.version }}/
+          production: ${{ env.production }}
+          temporary: ${{ env.production == 'true' && 'false' || 'true' }}
+          aws-role: ${{ vars.DOCS_AWS_ROLE }}
+
+      - name: Comment on PR
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
+        uses: actions/github-script@v7
+        env:
+            url: ${{ vars.DOCS_PREVIEW_URL }}
+        with:
+            script: |
+                const env = process.env;
+                github.rest.issues.createComment({
+                issue_number: env.version.replace('pr-', ''),
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `[Barrage docs preview](${env.url}/barrage/${env.version}/docs) (Available for 14 days)`
+                });

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,9 +27,8 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           token: ${{ secrets.GITHUB_TOKEN }}
           
-      - name: Deploy Docs
+      - name: Set deploy version
         run: |
-          echo "Deploying docs for tag: ${{ github.event.inputs.tag || github.ref_name }}"
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             pr_number=${{ github.event.pull_request.number }}
             echo "version=pr-${pr_number}" >> $GITHUB_ENV

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,11 +31,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
           else
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              echo "ref=dmckenzie_bring_docs_home" >> $GITHUB_ENV
-            else
-              echo "ref=48/merge" >> $GITHUB_ENV
-            fi
+            echo "ref=${{ github.ref_name }}" >> $GITHUB_ENV
           fi
 
       - name: Docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,15 +25,24 @@ jobs:
 
     steps:
 
+      # Checkout the repository
+      - name: Set ref variable
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
+          else
+            echo "ref=${{ github.event.inputs.tag || github.ref_name }}" >> $GITHUB_ENV
+
       - name: Docs
         run: |
-          echo "Resolved ref: ${{ github.event.inputs.tag || github.ref_name }}"
+          echo "Resolved event name: ${{ github.event_name }}"
+          echo "Resolved ref: ${{ env.ref }}"
 
-      # Checkout the repository
+
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.event.inputs.tag || github.ref_name }}
+          ref: ${{ env.ref }}
           
       - name: Deploy Docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          ref: ${{ github.event.inputs.tag || github.head_ref || github.ref_name }}
           
       - name: Deploy Docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,12 +24,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+      - name: Docs
+        run: |
+          echo "Resolved ref: ${{ github.event.inputs.tag || github.ref_name }}"
+
       # Checkout the repository
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.tag || github.ref_name }}
-
+          
       - name: Deploy Docs
         run: |
           echo "Deploying docs for tag: ${{ github.event.inputs.tag || github.ref_name }}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,23 @@
-Read documentation here: https://deephaven.io/barrage/docs/
+---
+title: Barrage
+slug: /docs
+---
 
-Edit docs in the [deephaven.io repo](https://github.com/deephaven/deephaven.io) (Deephaven GitHub org access only). External contributors, please open an issue with any errata.
+<div className="comment-title">
+
+Barrage is an extension of Apache Arrow Flight, with a particular focus on incrementally updating data sets.
+
+</div>
+
+We at Deephaven believe that it is Arrow's and similar projects' drive for efficient standards that enables a lot of
+the innovation we see in data science.
+
+We want to share the way we see data at Deephaven. We believe that live use cases are better served, both in
+latency and in throughput, by an iterative update model rather than a periodic refresh.
+
+Barrage introduces flatbuffer metadata types that are sent to/from a Barrage server via FlightData's metadata. The
+`BarrageMessageWrapper` is the expected outer type, but is intended to be a cheap model that is sensitive to custom
+user needs. The `BarrageUpdateMetadata` is the inner-type that contains the information
+needed to apply the update model. See [concepts](./concepts.md) for more information on the update model.
+
+<a className="button button--success" href="https://github.com/deephaven/barrage">Barrage Github Repo</a>

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,137 @@
+# Concepts
+
+The documentation on [Deephaven's table update model](https://deephaven.io/core/docs/conceptual/table-update-model/)
+is highly recommended supplement material.
+
+## Row Set
+
+Many of the messages that are sent by Barrage identify the set of rows that this update affects. These are ordered
+sets of rows in row key space. Sometimes we refer to these as an Index.
+
+To discuss sets of rows we need to be aware that each row of data has two identifiers.
+
+- Row Position Id
+- Row Key Id
+
+A RowSet is an ordered set of rows and may represent either the table's key-space
+or the table's position-space. Sometimes we refer to a row set as an Index.
+
+Indexes have a variety of uses. They:
+
+- describe which rows exist in a table (key-space)
+- describe which rows were added/removed/modified in a table (key-space)
+- describe a viewport (position-space)
+
+### Row Positions
+
+If a table has `n` rows then it has a position space of `[0, n-1]`. It is simply the ordering of rows if they were to
+be stored right next to each other in memory. Most user provided Row Sets are, for the convenience of the user,
+in row position space.
+
+### Row Keys
+
+The reality is that it's not efficient to store all of your records smushed together in a tight key space. For example,
+you cannot perform iterative sort in faster than `O(n * k)` if you have `n` records and `k` adds/mods/removes. However,
+if the protocol allows for spreading rows out then you can amortize a lot of this cost away. Many of our operations
+think of rows in the context of their row key identifier.
+
+> [!NOTE]
+> For example, let table T be defined by the set of rows with keys
+> `[0, 9], [100, 109], and [180, 189]`. In position space you can identify this
+> set as `[0, 29]`. Suppose that table T ticks and now is defined
+> by the set of rows with keys `[0, 9], [100, 109], and [310, 319]`. This is
+> still identified in position space as `[0, 29]`, however the 30th position-space
+> element now refers to key `319` instead of key `189`.
+
+## Viewport
+
+Depending on the final destination and use of the data, the developer may
+not necessarily want to subscribe to the entire dataset at once. If, for example, the
+data is destined for a human-facing widget then you may only need a slice
+of the data. We call these slices viewports.
+
+Viewports are in position space because:
+
+- they are difficult to synchronize with the server as the row key space may vary tick to tick.
+- the api more closely resembles a pagination over `n` records.
+
+## IndexShiftData
+
+Some operations need to be able to rearrange the keyspace to accommodate
+changes in data. For example, a sort may need to move rows that are adjacent in
+keyspace out of the way to accommodate a newly inserted row that sorts
+directly between them. When rows change in keyspace, we communicate these
+changes independently from additions, removals, and modifications.
+
+We call a single transformation a `shift`. A shift is defined by a `start`, `end`,
+and `delta`. All rows in the range `[start, end]` (inclusive) change in key-space by
+`delta` and are now located at `[start + delta, end + delta]`.
+
+Things get pretty tricky quickly. For practical reasons, there are a few restrictions:
+
+- shift origins are not allowed to overlap in pre-shift keyspace
+- shift destinations are not allowed to overlap in post-shift keyspace
+- shifts are unable to alter the ordering of rows in position space
+- positive deltas must be applied in high-to-low keyspace order
+- negative deltas must be applied in low-to-high keyspace order
+
+## Update Model
+
+In pseudo-code, an update (roughly) looks like:
+
+```java
+class Update {
+  Index added;  // post shift key-space
+  Index removed; // pre shift key-space
+  IndexShiftData shifted;
+  Index[] modifiedColumns; // post shift key-space
+}
+```
+
+To properly apply an update you must take care to apply it in order:
+
+1. remove data for all rows that were removed on this update
+2. apply the index shift data to your current state; your state is now in post-shift keyspace
+
+- note: positive deltas should be applied in highest to lowest order to avoid losing state
+- note: negative deltas should be applied in lowest to highest order to avoid losing state
+
+3. add data for all rows that were added on this update
+4. apply any modification that affects your state
+
+Modified columns are independent of each other and may
+have different sets of modified rows. This is caused by coalescing that must occur when the engine
+updates more frequently than the subscription allows.
+
+## Snapshot
+
+New subscriptions, and subscription changes, warrant a refresh of data that
+is in the view of their subscription. If the subscription is made without
+a viewport, it is assumed to be a full table subscription. Due to the
+asynchronous nature of table subscription, not every subscription change request
+is required to be responded to. Instead, the message will be marked as being
+a snapshot.
+
+Snapshots:
+
+- do not remove rows
+- do not modify rows
+- do not shift rows
+- the server may omit data the client has from an existing subscription
+- include the acknowledged viewport and subscribed column set
+
+## Scoped Rows
+
+Since viewports are in position-space, we need to be able to communicate data that
+shifts into view but is otherwise not new.
+
+Imagine the scenario:
+
+1. Let `T` be our imaginary table.
+2. Let `C` be a viewport client of `T` subscribed to position space `[100, 199]`.
+3. `T` ticks and removes rows in position space `[0, 19]`.
+4. The client now has data in position space `[80, 179]`; the server must send the missing `[180, 199]`.
+
+We call these rows `scoped` rows. They are integrated with `added` rows in an update,
+but are distinguishable via the `addedRowsIncluded` field included in the `BarrageRecordBatch`.
+See the [Wire Guide](./wire-guide.md) for more details.

--- a/docs/rpc-interface.md
+++ b/docs/rpc-interface.md
@@ -1,0 +1,246 @@
+# RPC Interface
+
+The Barrage extension works by sending additional metadata via the `app_metadata` field on `FlightData`. This metadata
+is used to communicate the necessary additional information between server and client. These types are flatbuffers, so
+that we may more easily lift the `app_metadata` into the `RecordBatch` flatbuffer once Arrow supports byte-array
+metadata, at that layer.
+
+The main subscription mechanism is initiated via a `DoExchange`. The client sends a SubscriptionRequest (or as many as
+they like) and the server sends barrage updates to satisfy their subscription's requirements.
+
+## Flat Buffer Definitions
+
+<!-- fbs, not ts, but we don't have a syntax highlighter for that -->
+
+```ts
+// Copyright 2020 Deephaven Data Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace io.deephaven.barrage.flatbuf;
+
+enum BarrageMessageType : byte {
+  /// A barrage message wrapper might send a None message type
+  /// if the msg_payload is empty.
+  None = 0,
+
+  /// for session management (not-yet-used)
+  NewSessionRequest = 1,
+  RefreshSessionRequest = 2,
+  SessionInfoResponse = 3,
+
+  /// for subscription parsing/management (aka DoPut, DoExchange)
+  BarrageSerializationOptions = 4,
+  BarrageSubscriptionRequest = 5,
+  BarrageUpdateMetadata = 6,
+  BarrageSnapshotRequest = 7,
+  BarragePublicationRequest = 8,
+
+  // enum values greater than 127 are reserved for custom client use
+}
+
+/// The message wrapper used for all barrage app_metadata fields.
+table BarrageMessageWrapper {
+  /// Used to identify this type of app_metadata vs other applications.
+  /// The magic value is '0x6E687064'. It is the numerical representation of the ASCII "dphn".
+  magic: uint;
+
+  /// The msg type being sent.
+  msg_type: BarrageMessageType;
+
+  /// The msg payload.
+  msg_payload: [byte];
+}
+
+/// Establish a new session.
+table NewSessionRequest {
+  /// A nested protocol version (gets delegated to handshake)
+  protocol_version: uint;
+
+  /// Arbitrary auth/handshake info.
+  payload: [byte];
+}
+
+/// Refresh the provided session.
+table RefreshSessionRequest {
+  /// this session token is only required if it is the first request of a handshake rpc stream
+  session: [byte];
+}
+
+/// Information about the current session state.
+table SessionInfoResponse {
+  /// this is the metadata header to identify this session with future requests; it must be lower-case and remain static for the life of the session
+  metadata_header: [byte];
+
+  /// this is the session_token; note that it may rotate
+  session_token: [byte];
+
+  /// a suggested time for the user to refresh the session if they do not do so earlier; value is denoted in milliseconds since epoch
+  token_refresh_deadline_ms: long;
+}
+
+/// There will always be types that cannot be easily supported over IPC. These are the options:
+///   Stringify (default) - Pretend the column is a string when sending over Arrow Flight (default)
+///   JavaSerialization   - Use java serialization; the client is responsible for the deserialization
+///   ThrowError          - Refuse to send the column and throw an internal error sharing as much detail as possible
+enum ColumnConversionMode : byte { Stringify = 1, JavaSerialization, ThrowError }
+
+table BarrageSubscriptionOptions {
+  /// see enum for details
+  column_conversion_mode: ColumnConversionMode = Stringify;
+
+  /// Deephaven reserves a value in the range of primitives as a custom NULL value. This enables more efficient transmission
+  /// by eliminating the additional complexity of the validity buffer.
+  use_deephaven_nulls: bool;
+
+  /// Explicitly set the update interval for this subscription. Note that subscriptions with different update intervals
+  /// cannot share intermediary state with other subscriptions and greatly increases the footprint of the non-conforming subscription.
+  ///
+  /// Note: if not supplied (default of zero) then the server uses a consistent value to be efficient and fair to all clients
+  min_update_interval_ms: int;
+
+  /// Specify a preferred batch size. Server is allowed to be configured to restrict possible values. Too small of a
+  /// batch size may be dominated with header costs as each batch is wrapped into a separate RecordBatch. Too large of
+  /// a payload and it may not fit within the maximum payload size. A good default might be 4096.
+  batch_size: int;
+
+  /// Specify a maximum allowed message size. Server will enforce this limit by reducing batch size (to a lower limit
+  /// of one row per batch). If the message size limit cannot be met due to large row sizes, the server will throw a
+  /// `Status.RESOURCE_EXHAUSTED` exception
+  max_message_size: int;
+}
+
+/// Describes the subscription the client would like to acquire.
+table BarrageSubscriptionRequest {
+  /// Ticket for the source data set.
+  ticket: [byte];
+
+  /// The bitset of columns to subscribe. If not provided then all columns are subscribed.
+  columns: [byte];
+
+  /// This is an encoded and compressed RowSet in position-space to subscribe to. If not provided then the entire
+  /// table is requested.
+  viewport: [byte];
+
+  /// Options to configure your subscription.
+  subscription_options: BarrageSubscriptionOptions;
+
+  /// When this is set the viewport RowSet will be inverted against the length of the table. That is to say
+  /// every position value is converted from `i` to `n - i - 1` if the table has `n` rows.
+  reverse_viewport: bool;
+}
+
+table BarrageSnapshotOptions {
+  /// see enum for details
+  column_conversion_mode: ColumnConversionMode = Stringify;
+
+  /// Deephaven reserves a value in the range of primitives as a custom NULL value. This enables more efficient transmission
+  /// by eliminating the additional complexity of the validity buffer.
+  use_deephaven_nulls: bool;
+
+  /// Specify a preferred batch size. Server is allowed to be configured to restrict possible values. Too small of a
+  /// batch size may be dominated with header costs as each batch is wrapped into a separate RecordBatch. Too large of
+  /// a payload and it may not fit within the maximum payload size. A good default might be 4096.
+  batch_size: int;
+
+  /// Specify a maximum allowed message size. Server will enforce this limit by reducing batch size (to a lower limit
+  /// of one row per batch). If the message size limit cannot be met due to large row sizes, the server will throw a
+  /// `Status.RESOURCE_EXHAUSTED` exception
+  max_message_size: int;
+}
+
+/// Describes the snapshot the client would like to acquire.
+table BarrageSnapshotRequest {
+  /// Ticket for the source data set.
+  ticket: [byte];
+
+  /// The bitset of columns to request. If not provided then all columns are requested.
+  columns: [byte];
+
+  /// This is an encoded and compressed RowSet in position-space to subscribe to. If not provided then the entire
+  /// table is requested.
+  viewport: [byte];
+
+  /// Options to configure your subscription.
+  snapshot_options: BarrageSnapshotOptions;
+
+  /// When this is set the viewport RowSet will be inverted against the length of the table. That is to say
+  /// every position value is converted from `i` to `n - i - 1` if the table has `n` rows.
+  reverse_viewport: bool;
+}
+
+table BarragePublicationOptions {
+  /// Deephaven reserves a value in the range of primitives as a custom NULL value. This enables more efficient transmission
+  /// by eliminating the additional complexity of the validity buffer.
+  use_deephaven_nulls: bool;
+}
+
+/// Describes the table update stream the client would like to push to. This is similar to a DoPut but the client
+/// will send BarrageUpdateMetadata to explicitly describe the row key space. The updates sent adhere to the table
+/// update model semantics; thus BarragePublication enables the client to upload a ticking table.
+table BarragePublicationRequest {
+  /// The destination Ticket.
+  ticket: [byte];
+
+  /// Options to configure your request.
+  publish_options: BarragePublicationOptions;
+}
+
+/// Holds all of the rowset data structures for the column being modified.
+table BarrageModColumnMetadata {
+  /// This is an encoded and compressed RowSet for this column (within the viewport) that were modified.
+  /// There is no notification for modifications outside of the viewport.
+  modified_rows: [byte];
+}
+
+/// A data header describing the shared memory layout of a "record" or "row"
+/// batch for a ticking barrage table.
+table BarrageUpdateMetadata {
+  /// This batch is generated from an upstream table that ticks independently of the stream. If
+  /// multiple events are coalesced into one update, the server may communicate that here for
+  /// informational purposes.
+  first_seq: long;
+  last_seq: long;
+
+  /// Indicates if this message was sent due to upstream ticks or due to a subscription change.
+  is_snapshot: bool;
+
+  /// If this is a snapshot and the subscription is a viewport, then the effectively subscribed viewport
+  /// will be included in the payload. It is an encoded and compressed RowSet.
+  effective_viewport: [byte];
+
+  /// When this is set the viewport RowSet will be inverted against the length of the table. That is to say
+  /// every position value is converted from `i` to `n - i - 1` if the table has `n` rows.
+  effective_reverse_viewport: bool;
+
+  /// If this is a snapshot, then the effectively subscribed column set will be included in the payload.
+  effective_column_set: [byte];
+
+  /// This is an encoded and compressed RowSet that was added in this update.
+  added_rows: [byte];
+
+  /// This is an encoded and compressed RowSet that was removed in this update.
+  removed_rows: [byte];
+
+  /// This is an encoded and compressed RowSetShiftData describing how the keyspace of unmodified rows changed.
+  shift_data: [byte];
+
+  /// This is an encoded and compressed RowSet that was included with this update.
+  /// (the server may include rows not in addedRows if this is a viewport subscription to refresh
+  ///  unmodified rows that were scoped into view)
+  added_rows_included: [byte];
+
+  /// The list of modified column data are in the same order as the field nodes on the schema.
+  mod_column_nodes: [BarrageModColumnMetadata];
+}
+```

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/deephaven/salmon-sync/refs/heads/main/sidebar.schema.json",
+  "config": {
+    "name": "Deephaven Barrage Docs"
+  },
+  "sidebars": {
+    "main": [
+      {
+        "label": "Introduction",
+        "path": "README.md"
+      },
+      {
+        "label": "Concepts",
+        "path": "concepts.md"
+      },
+      {
+        "label": "RPC Interface",
+        "path": "rpc-interface.md"
+      },
+      {
+        "label": "Wire Guide",
+        "path": "wire-guide.md"
+      }
+    ]
+  }
+}

--- a/docs/wire-guide.md
+++ b/docs/wire-guide.md
@@ -1,0 +1,83 @@
+# Wire Guide
+
+There are three different wire types that you will need to become familiar with to parse and process a
+`BarrageUpdateMetadata`. You will also need to know how to write your own Row Set to set a viewport.
+
+## Row Set Wire Format
+
+A Row Set is serialized as a series of commands. Each command is one-byte
+split into a 5-bit (high) value and a 3-bit (low) value.
+
+> [!NOTE]
+> [Deephaven Enterprise](https://deephaven.io/enterprise/) uses the term `Index` instead of `Row Set` to refer to this concept.
+
+Possible Command Types (most significant 5 bits):
+
+```java
+OFFSET      = 1;
+SHORT_ARRAY = 2;
+BYTE_ARRAY  = 3;
+END         = 4;
+```
+
+Possible Value Types (low 3 bits):
+
+```java
+SHORT_VALUE = 1; // 2 bytes
+INT_VALUE   = 2; // 4 bytes
+LONG_VALUE  = 3; // 8 bytes
+BYTE_VALUE  = 4; // 1 byte
+```
+
+To parse, continue reading until receiving a command type of `END`. Immediately
+following a non-end command is the little-endian-encoded value with length
+denoted by provided value type. If command type is byte array or short array,
+then the value is the number of elements that follow. These elements are either
+shorts or bytes depending on the command type. The offset command is a single
+value (then followed by the next command).
+
+The series of values parsed from the previous paragraph can be used to
+reconstruct a Row Set. Since a Row Set is an ordered set, all of the values that
+we insert should always be increasing and thus positive. The algorithm then
+uses the sign to encode a single value (a positive value) vs a rangle
+(a positive value followed by a negative value).
+
+To reconstruct the Row Set run the parsed values through this pseudo code:
+
+```java
+long pending = -1;
+long lastValue = 0;
+void consume(long nextOffset) {
+    if (nextOffset < 0) {
+        assert(pending != -1);
+        lastValue = lastValue - nextOffset;
+        addRowsInRange(pending, lastValue);
+        pending = -1;
+    } else {
+        if (pending != -1) {
+            addRowAt(pending);
+        }
+        lastValue = pending = lastValue + nextOffset;
+    }
+}
+```
+
+## RowSetShiftData Wire Format
+
+To implement [row shifts](https://deephaven.io/core/docs/conceptual/table-update-model/#shifts),
+`RowSetShiftData` is a binary encoding of three `Row Set` encodings without any padding in-between.
+
+The three Row Sets are `starts`, `ends` and `dests`. Each Row Set will have the
+same length. Let `s_i = starts[i]`, `e_i = ends[i]`, `d_i = dests[i]`, then this
+triplet represents the notification that all data in keyspace `[s_i, e_i]` (inclusive)
+moved to `[d_i, d_i + e_i - s_i]`.
+
+> [!NOTE]
+> Note that not all rows are required to exist within the shift; it is recommended to avoid iterating through
+> he entire range. See [RowSetShiftData](https://github.com/deephaven/deephaven-core/blob/main/engine/rowset/src/main/java/io/deephaven/engine/rowset/RowSetShiftData.java)
+> for inspiration.
+
+## BitSet Wire Format
+
+The bitset is represented in little-endian byte-ordered bits. Assume
+that all omitted bits are zero.


### PR DESCRIPTION
Move docs from deephaven.io repo back home. Adjust formatting and sidebar.json for salmon publishing.

Add action to publish new docs when release is tagged, and preview for PRs.

Fixes: DOC-703